### PR TITLE
Moved comment out of array -- vim doesn't like that

### DIFF
--- a/autoload/EasyClip/Yank.vim
+++ b/autoload/EasyClip/Yank.vim
@@ -258,15 +258,15 @@ endfunction
 
 function! EasyClip#Yank#SetDefaultMappings()
 
+    let bindings =
     \ [
     \   ['Y',  ':EasyClipBeforeYank<cr>y$:EasyClipOnYanksChanged<cr>',  'n',  0],
     \   ['y',  '<Plug>YankPreserveCursorPosition',  'n',  1],
     \   ['yy',  '<Plug>YankLinePreserveCursorPosition',  'n',  1],
     \   ['y',  '<Plug>VisualModeYank',  'x',  1],
     \ ]
-    
+
     " Let the user set [y themselves so that we don't conflict with vim-unimpaired
-    let bindings =
     "\   ['[y',  '<plug>EasyClipRotateYanksForward',  'n',  1],
     "\   [']y',  '<plug>EasyClipRotateYanksBackward',  'n',  1],
 

--- a/autoload/EasyClip/Yank.vim
+++ b/autoload/EasyClip/Yank.vim
@@ -258,16 +258,17 @@ endfunction
 
 function! EasyClip#Yank#SetDefaultMappings()
 
-    " Let the user set [y themselves so that we don't conflict with vim-unimpaired
-    let bindings =
     \ [
-    "\   ['[y',  '<plug>EasyClipRotateYanksForward',  'n',  1],
-    "\   [']y',  '<plug>EasyClipRotateYanksBackward',  'n',  1],
     \   ['Y',  ':EasyClipBeforeYank<cr>y$:EasyClipOnYanksChanged<cr>',  'n',  0],
     \   ['y',  '<Plug>YankPreserveCursorPosition',  'n',  1],
     \   ['yy',  '<Plug>YankLinePreserveCursorPosition',  'n',  1],
     \   ['y',  '<Plug>VisualModeYank',  'x',  1],
     \ ]
+    
+    " Let the user set [y themselves so that we don't conflict with vim-unimpaired
+    let bindings =
+    "\   ['[y',  '<plug>EasyClipRotateYanksForward',  'n',  1],
+    "\   [']y',  '<plug>EasyClipRotateYanksBackward',  'n',  1],
 
     for binding in bindings
         call call("EasyClip#AddWeakMapping", binding)


### PR DESCRIPTION
Moved commented values out of array -- vim doesn't like that

This might work too, haven't tried it:

```
 \ "  ['[y',  '<plug>EasyClipRotateYanksForward',  'n',  1],
```
